### PR TITLE
fix: change nonce parameters from u8 to u64 to support larger nonce values

### DIFF
--- a/crates/safe-hash/src/cli.rs
+++ b/crates/safe-hash/src/cli.rs
@@ -38,7 +38,7 @@ pub struct TransactionArgs {
 
     /// Transaction nonce of the safe address
     #[arg(short, long, required = true)]
-    pub nonce: u8,
+    pub nonce: u64,
 
     /// Address of the safe address
     #[arg(short = 's', long = "safe-address", required = true)]
@@ -70,7 +70,7 @@ pub struct TransactionArgs {
 
     /// Nested safe nonce
     #[arg(long)]
-    pub nested_safe_nonce: Option<u8>,
+    pub nested_safe_nonce: Option<u64>,
 
     #[arg(long, default_value_t = U256::ZERO)]
     pub safe_tx_gas: U256,

--- a/crates/safe-hash/src/tx_signing.rs
+++ b/crates/safe-hash/src/tx_signing.rs
@@ -58,7 +58,7 @@ impl TxInput {
 pub fn tx_signing_hashes(
     tx_data: &TxInput,
     safe_address: Address,
-    nonce: u8,
+    nonce: u64,
     chain_id: ChainId,
     safe_version: SafeWalletVersion,
 ) -> SafeHashes {


### PR DESCRIPTION
## Problem

The safe-hash-rs project had a bug where nonce parameters were defined as `u8` instead of `u64`, causing errors like "xxx is not in 0..=255" when trying to use nonce values greater than 255.

## Root Cause

Three locations in the codebase had incorrect type definitions:
1. `crates/safe-hash/src/cli.rs` - `pub nonce: u8` (line 42)
2. `crates/safe-hash/src/cli.rs` - `pub nested_safe_nonce: Option<u8>` (line 70)  
3. `crates/safe-hash/src/tx_signing.rs` - `nonce: u8` in function signature (line 60)

## Solution

Changed all three locations from `u8` to `u64` to support much larger nonce values.

## Testing

Verified the fix works by successfully running:
- `safe-hash tx --chain ethereum --nonce 276 --safe-address 0x... --to 0x... --safe-version 1.3.0`
- `safe-hash tx --chain ethereum --nonce 276 --safe-address 0x... --to 0x... --safe-version 1.3.0 --nested-safe-address 0x... --nested-safe-nonce 300`

This will resolve the problem for users who have Safe wallets with nonce values greater than 255, which is a common scenario for active Safe wallets.